### PR TITLE
Fix incorrect using of WSDL methods

### DIFF
--- a/soap/client.go
+++ b/soap/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 )
 
+const XSINamespace = "http://www.w3.org/2001/XMLSchema-instance"
+
 // A RoundTripper executes a request passing the given req as the SOAP
 // envelope body. The HTTP response is then de-serialized onto the resp
 // object. Returns error in case an error occurs serializing req, making
@@ -36,19 +38,22 @@ type AuthHeader struct {
 
 // Client is a SOAP client.
 type Client struct {
-	URL         string              // URL of the server
-	Namespace   string              // SOAP Namespace
-	Envelope    string              // Optional SOAP Envelope
-	Header      Header              // Optional SOAP Header
-	ContentType string              // Optional Content-Type (default text/xml)
-	Config      *http.Client        // Optional HTTP client
-	Pre         func(*http.Request) // Optional hook to modify outbound requests
+	URL                    string              // URL of the server
+	Namespace              string              // SOAP Namespace
+	XSINamespace           string              // Include xsi Namespace to SOAP Action header
+	ExcludeActionNamespace bool                // Include Namespace to SOAP Action header
+	Envelope               string              // Optional SOAP Envelope
+	Header                 Header              // Optional SOAP Header
+	ContentType            string              // Optional Content-Type (default text/xml)
+	Config                 *http.Client        // Optional HTTP client
+	Pre                    func(*http.Request) // Optional hook to modify outbound requests
 }
 
 func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) error {
 	req := &Envelope{
 		EnvelopeAttr: c.Envelope,
 		NSAttr:       c.Namespace,
+		XSIAttr:      c.XSINamespace,
 		Header:       c.Header,
 		Body:         Body{Message: in},
 	}
@@ -93,13 +98,19 @@ func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) err
 // RoundTrip implements the RoundTripper interface.
 func (c *Client) RoundTrip(soapAction string, in, out Message) error {
 	headerFunc := func(r *http.Request) {
+		var actionName string
 		ct := c.ContentType
 		if ct == "" {
 			ct = "text/xml"
 		}
 		r.Header.Set("Content-Type", ct)
 		if in != nil {
-			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, soapAction))
+			if c.ExcludeActionNamespace {
+				actionName = soapAction
+			} else {
+				actionName = fmt.Sprintf("%s/%s", c.Namespace, soapAction)
+			}
+			r.Header.Add("SOAPAction", actionName)
 		}
 	}
 	return doRoundTrip(c, headerFunc, in, out)
@@ -117,6 +128,7 @@ type Envelope struct {
 	XMLName      xml.Name `xml:"SOAP-ENV:Envelope"`
 	EnvelopeAttr string   `xml:"xmlns:SOAP-ENV,attr"`
 	NSAttr       string   `xml:"xmlns:ns,attr"`
+	XSIAttr      string   `xml:"xmlns:xsi,attr,omitempty"`
 	Header       Message  `xml:"SOAP-ENV:Header"`
 	Body         Body
 }

--- a/soap/client.go
+++ b/soap/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 )
 
 // A RoundTripper executes a request passing the given req as the SOAP
@@ -92,7 +91,7 @@ func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) err
 }
 
 // RoundTrip implements the RoundTripper interface.
-func (c *Client) RoundTrip(in, out Message) error {
+func (c *Client) RoundTrip(soapAction string, in, out Message) error {
 	headerFunc := func(r *http.Request) {
 		ct := c.ContentType
 		if ct == "" {
@@ -100,7 +99,7 @@ func (c *Client) RoundTrip(in, out Message) error {
 		}
 		r.Header.Set("Content-Type", ct)
 		if in != nil {
-			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, reflect.TypeOf(in).Elem().Name()))
+			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, soapAction))
 		}
 	}
 	return doRoundTrip(c, headerFunc, in, out)

--- a/soap/client_test.go
+++ b/soap/client_test.go
@@ -1,12 +1,12 @@
 package soap
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
-	"fmt"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -28,27 +28,31 @@ func TestRoundTrip(t *testing.T) {
 	pre := func(r *http.Request) { r.Header.Set("X-Test", "true") }
 	cases := []struct {
 		C       *Client
+		Action  string
 		In, Out Message
 		Fail    bool
 	}{
 		{
-			C:   &Client{URL: s.URL, Pre: pre},
-			In:  &msgT{A: "hello", B: "world"},
-			Out: &envT{},
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "hello",
+			In:     &msgT{A: "hello", B: "world"},
+			Out:    &envT{},
 		},
 		{
-			C:   &Client{URL: s.URL, Pre: pre},
-			In:  &msgT{A: "foo", B: "bar"},
-			Out: &envT{},
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "foo",
+			In:     &msgT{A: "foo", B: "bar"},
+			Out:    &envT{},
 		},
 		{
-			C:    &Client{URL: "", Pre: pre},
-			Out:  &envT{},
-			Fail: true,
+			C:      &Client{URL: "", Pre: pre},
+			Action: "none",
+			Out:    &envT{},
+			Fail:   true,
 		},
 	}
 	for i, tc := range cases {
-		err := tc.C.RoundTrip(tc.In, tc.Out)
+		err := tc.C.RoundTrip(tc.Action, tc.In, tc.Out)
 		if err != nil && !tc.Fail {
 			t.Errorf("test %d: %v", i, err)
 			continue

--- a/soap/client_test.go
+++ b/soap/client_test.go
@@ -52,7 +52,71 @@ func TestRoundTrip(t *testing.T) {
 		},
 	}
 	for i, tc := range cases {
-		err := tc.C.RoundTrip(tc.Action, tc.In, tc.Out)
+		err := tc.C.RoundTrip(tc.In, tc.Out)
+		if err != nil && !tc.Fail {
+			t.Errorf("test %d: %v", i, err)
+			continue
+		}
+		if tc.Fail {
+			continue
+		}
+		env, ok := tc.Out.(*envT)
+		if !ok {
+			t.Errorf("test %d: response to %#v is not an envelope", i, tc.In)
+			continue
+		}
+		if !reflect.DeepEqual(env.Body.Message, *tc.In.(*msgT)) {
+			t.Errorf("test %d: message mismatch\nwant: %#v\nhave: %#v",
+				i, tc.In, &env.Body.Message)
+			continue
+		}
+	}
+}
+
+func TestRoundTripWithAction(t *testing.T) {
+	type msgT struct{ A, B string }
+	type envT struct{ Body struct{ Message msgT } }
+	echo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.NotFound(w, r)
+			return
+		}
+		if v := r.Header.Get("X-Test"); v != "true" {
+			http.NotFound(w, r)
+			return
+		}
+		io.Copy(w, r.Body)
+	})
+	s := httptest.NewServer(echo)
+	defer s.Close()
+	pre := func(r *http.Request) { r.Header.Set("X-Test", "true") }
+	cases := []struct {
+		C       *Client
+		Action  string
+		In, Out Message
+		Fail    bool
+	}{
+		{
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "hello",
+			In:     &msgT{A: "hello", B: "world"},
+			Out:    &envT{},
+		},
+		{
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "foo",
+			In:     &msgT{A: "foo", B: "bar"},
+			Out:    &envT{},
+		},
+		{
+			C:      &Client{URL: "", Pre: pre},
+			Action: "none",
+			Out:    &envT{},
+			Fail:   true,
+		},
+	}
+	for i, tc := range cases {
+		err := tc.C.RoundTripWithAction(tc.Action, tc.In, tc.Out)
 		if err != nil && !tc.Fail {
 			t.Errorf("test %d: %v", i, err)
 			continue

--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -203,8 +203,8 @@ type BindingOperation struct {
 // Soap12Operation.SoapAction is used to switch things over to sending
 // a soap 1.2 content type header (application/xml; charset=UTF-8; action='blah')
 type Soap12Operation struct {
-	XMLName    xml.Name   `xml:"http://schemas.xmlsoap.org/wsdl/soap12/ operation"`
-	SoapAction string     `xml:"soapAction,attr"`
+	XMLName    xml.Name `xml:"http://schemas.xmlsoap.org/wsdl/soap12/ operation"`
+	SoapAction string   `xml:"soapAction,attr"`
 }
 
 // BindingIO describes the IO binding of SOAP operations. See IO for details.

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -492,7 +492,7 @@ var soapFuncT = template.Must(template.New("soapFunc").Parse(
 			M {{.OutputType}} ` + "`xml:\"{{.XMLOutputType}}\"`" + `
 		}
 	}{}
-	if err = p.cli.RoundTrip("{{.Name}}", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("{{.Name}}", α, &γ); err != nil {
 		return {{.RetDef}}, err
 	}
 	return {{if .RetPtr}}&{{end}}γ.Body.M, nil

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -65,7 +65,7 @@ type goEncoder struct {
 	needsTimeType     bool
 	needsDateTimeType bool
 	needsDurationType bool
-	needsTag          map[string]bool
+	needsTag          map[string]string
 	needsStdPkg       map[string]bool
 	needsExtPkg       map[string]bool
 }
@@ -81,7 +81,7 @@ func NewEncoder(w io.Writer) Encoder {
 		funcs:       make(map[string]*wsdl.Operation),
 		messages:    make(map[string]*wsdl.Message),
 		soapOps:     make(map[string]*wsdl.BindingOperation),
-		needsTag:    make(map[string]bool),
+		needsTag:    make(map[string]string),
 		needsStdPkg: make(map[string]bool),
 		needsExtPkg: make(map[string]bool),
 	}
@@ -492,7 +492,7 @@ var soapFuncT = template.Must(template.New("soapFunc").Parse(
 			M {{.OutputType}} ` + "`xml:\"{{.XMLOutputType}}\"`" + `
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("{{.Name}}", α, &γ); err != nil {
 		return {{.RetDef}}, err
 	}
 	return {{if .RetPtr}}&{{end}}γ.Body.M, nil
@@ -580,7 +580,6 @@ func (ge *goEncoder) writeSOAPFunc(w io.Writer, d *wsdl.Definitions, op *wsdl.Op
 	return true
 }
 
-
 func renameParam(p, name string) string {
 	v := strings.SplitN(p, " ", 2)
 	if len(v) != 2 {
@@ -660,13 +659,19 @@ func code(list []*parameter) []string {
 func (ge *goEncoder) genParams(m *wsdl.Message, needsTag bool) []*parameter {
 	params := make([]*parameter, len(m.Parts))
 	for i, param := range m.Parts {
-		var t, token string
+		var t, token, elName string
 		switch {
 		case param.Type != "":
 			t = ge.wsdl2goType(param.Type)
+			elName = ge.trimns(param.Type)
 			token = t
 		case param.Element != "":
-			t = ge.wsdl2goType(param.Element)
+			elName = ge.trimns(param.Element)
+			if el, ok := ge.elements[elName]; ok {
+				t = ge.wsdl2goType(ge.trimns(el.Type))
+			} else {
+				t = ge.wsdl2goType(param.Element)
+			}
 			token = ge.trimns(param.Element)
 		}
 		name := param.Name
@@ -675,7 +680,7 @@ func (ge *goEncoder) genParams(m *wsdl.Message, needsTag bool) []*parameter {
 		}
 		params[i] = &parameter{code: name + " " + t, xmlToken: token}
 		if needsTag {
-			ge.needsTag[strings.TrimPrefix(t, "*")] = true
+			ge.needsTag[strings.TrimPrefix(t, "*")] = elName
 		}
 	}
 	return params
@@ -965,9 +970,9 @@ func (ge *goEncoder) genGoStruct(w io.Writer, d *wsdl.Definitions, ct *wsdl.Comp
 		return nil
 	}
 	fmt.Fprintf(w, "type %s struct {\n", name)
-	if ge.needsTag[name] {
+	if elName, ok := ge.needsTag[name]; ok {
 		fmt.Fprintf(w, "XMLName xml.Name `xml:\"%s %s\" json:\"-\" yaml:\"-\"`\n",
-			d.TargetNamespace, ct.Name)
+			d.TargetNamespace, elName)
 	}
 	err := ge.genStructFields(w, d, ct)
 	if err != nil {

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -72,7 +72,7 @@ func (p *dataEndpointPortType) GetData(α *GetData) (β *GetDataResp, err error)
 			M GetDataResp `xml:"getDataResp"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetData", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -72,7 +72,7 @@ func (p *dataEndpointPortType) GetData(α *GetData) (β *GetDataResp, err error)
 			M GetDataResp `xml:"getDataResp"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetData", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetData", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/memcache.golden
+++ b/wsdlgo/testdata/memcache.golden
@@ -51,7 +51,7 @@ type SetRequest struct {
 
 // GetMultiRequest was auto-generated from WSDL.
 type GetMultiRequest struct {
-	XMLName xml.Name `xml:"http://localhost:8080/MemoryService.wsdl getMultiRequest" json:"-" yaml:"-"`
+	XMLName xml.Name `xml:"http://localhost:8080/MemoryService.wsdl GetMultiRequest" json:"-" yaml:"-"`
 	Keys    []string `xml:"Keys" json:"Keys" yaml:"Keys"`
 }
 
@@ -68,7 +68,7 @@ func (p *memoryServicePortType) Get(α string) (β *GetResponse, err error) {
 			M GetResponse `xml:"GetResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("Get", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -82,7 +82,7 @@ func (p *memoryServicePortType) GetMulti(α *GetMultiRequest) (β *GetMultiRespo
 			M GetMultiResponse `xml:"GetMultiResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetMulti", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -96,7 +96,7 @@ func (p *memoryServicePortType) Set(α *SetRequest) (β bool, err error) {
 			M bool `xml:"bool"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("Set", α, &γ); err != nil {
 		return false, err
 	}
 	return γ.Body.M, nil

--- a/wsdlgo/testdata/memcache.golden
+++ b/wsdlgo/testdata/memcache.golden
@@ -68,7 +68,7 @@ func (p *memoryServicePortType) Get(α string) (β *GetResponse, err error) {
 			M GetResponse `xml:"GetResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("Get", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("Get", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -82,7 +82,7 @@ func (p *memoryServicePortType) GetMulti(α *GetMultiRequest) (β *GetMultiRespo
 			M GetMultiResponse `xml:"GetMultiResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetMulti", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetMulti", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -96,7 +96,7 @@ func (p *memoryServicePortType) Set(α *SetRequest) (β bool, err error) {
 			M bool `xml:"bool"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("Set", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("Set", α, &γ); err != nil {
 		return false, err
 	}
 	return γ.Body.M, nil

--- a/wsdlgo/testdata/soap12wcf.golden
+++ b/wsdlgo/testdata/soap12wcf.golden
@@ -18,7 +18,7 @@ func NewTest(cli *soap.Client) Test {
 // and defines interface for the remote service. Useful for testing.
 type Test interface {
 	// HelloWorld was auto-generated from WSDL.
-	HelloWorld(α *HelloRequest) (β *HelloResponse, err error)
+	HelloWorld(α string) (β string, err error)
 }
 
 // test implements the Test interface.
@@ -27,15 +27,15 @@ type test struct {
 }
 
 // HelloWorld was auto-generated from WSDL.
-func (p *test) HelloWorld(α *HelloRequest) (β *HelloResponse, err error) {
+func (p *test) HelloWorld(α string) (β string, err error) {
 	γ := struct {
 		XMLName xml.Name `xml:"Envelope"`
 		Body    struct {
-			M HelloResponse `xml:"HelloResponse"`
+			M string `xml:"HelloResponse"`
 		}
 	}{}
 	if err = p.cli.RoundTripSoap12("http://example.com/Test/HelloWorldRequest", α, &γ); err != nil {
-		return nil, err
+		return "", err
 	}
-	return &γ.Body.M, nil
+	return γ.Body.M, nil
 }

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -51,7 +51,7 @@ func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(α *GetEndorsingBoarde
 			M GetEndorsingBoarderResponse `xml:"GetEndorsingBoarderResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetEndorsingBoarder", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetEndorsingBoarder", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -51,7 +51,7 @@ func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(α *GetEndorsingBoarde
 			M GetEndorsingBoarderResponse `xml:"GetEndorsingBoarderResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetEndorsingBoarder", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -45,7 +45,7 @@ func (p *stockQuotePortType) GetLastTradePrice(α *TradePriceRequest) (β *Trade
 			M TradePrice `xml:"TradePrice"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -45,7 +45,7 @@ func (p *stockQuotePortType) GetLastTradePrice(α *TradePriceRequest) (β *Trade
 			M TradePrice `xml:"TradePrice"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetLastTradePrice", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil


### PR DESCRIPTION
- Pass SOAP action as argument to SOAP client, since it's
  a wrong to use WSDL message parameter name as SOAP action
  It may have a few parameters, so the SOAP action is the name of
  WSDL operation
- Fix wsdl function parameter type to use the type name like in WSDL
  Before it generated wsdl function with type as WSDL message.name
