### PR TITLE
Add supporting XML for abstract types

### DIFF
--- a/soap/client.go
+++ b/soap/client.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 )
 
+const XSINamespace = "http://www.w3.org/2001/XMLSchema-instance"
+
 // A RoundTripper executes a request passing the given req as the SOAP
 // envelope body. The HTTP response is then de-serialized onto the resp
 // object. Returns error in case an error occurs serializing req, making
@@ -36,19 +38,22 @@ type AuthHeader struct {
 
 // Client is a SOAP client.
 type Client struct {
-	URL         string              // URL of the server
-	Namespace   string              // SOAP Namespace
-	Envelope    string              // Optional SOAP Envelope
-	Header      Header              // Optional SOAP Header
-	ContentType string              // Optional Content-Type (default text/xml)
-	Config      *http.Client        // Optional HTTP client
-	Pre         func(*http.Request) // Optional hook to modify outbound requests
+	URL                    string              // URL of the server
+	Namespace              string              // SOAP Namespace
+	XSINamespace           string              // Include xsi Namespace to SOAP Action header
+	ExcludeActionNamespace bool                // Include Namespace to SOAP Action header
+	Envelope               string              // Optional SOAP Envelope
+	Header                 Header              // Optional SOAP Header
+	ContentType            string              // Optional Content-Type (default text/xml)
+	Config                 *http.Client        // Optional HTTP client
+	Pre                    func(*http.Request) // Optional hook to modify outbound requests
 }
 
 func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) error {
 	req := &Envelope{
 		EnvelopeAttr: c.Envelope,
 		NSAttr:       c.Namespace,
+		XSIAttr:      c.XSINamespace,
 		Header:       c.Header,
 		Body:         Body{Message: in},
 	}
@@ -93,13 +98,19 @@ func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) err
 // RoundTrip implements the RoundTripper interface.
 func (c *Client) RoundTrip(soapAction string, in, out Message) error {
 	headerFunc := func(r *http.Request) {
+		var actionName string
 		ct := c.ContentType
 		if ct == "" {
 			ct = "text/xml"
 		}
 		r.Header.Set("Content-Type", ct)
 		if in != nil {
-			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, soapAction))
+			if c.ExcludeActionNamespace {
+				actionName = soapAction
+			} else {
+				actionName = fmt.Sprintf("%s/%s", c.Namespace, soapAction)
+			}
+			r.Header.Add("SOAPAction", actionName)
 		}
 	}
 	return doRoundTrip(c, headerFunc, in, out)
@@ -117,6 +128,7 @@ type Envelope struct {
 	XMLName      xml.Name `xml:"SOAP-ENV:Envelope"`
 	EnvelopeAttr string   `xml:"xmlns:SOAP-ENV,attr"`
 	NSAttr       string   `xml:"xmlns:ns,attr"`
+	XSIAttr      string   `xml:"xmlns:xsi,attr,omitempty"`
 	Header       Message  `xml:"SOAP-ENV:Header"`
 	Body         Body
 }

--- a/soap/client.go
+++ b/soap/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 )
 
 // A RoundTripper executes a request passing the given req as the SOAP
@@ -92,7 +91,7 @@ func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) err
 }
 
 // RoundTrip implements the RoundTripper interface.
-func (c *Client) RoundTrip(in, out Message) error {
+func (c *Client) RoundTrip(soapAction string, in, out Message) error {
 	headerFunc := func(r *http.Request) {
 		ct := c.ContentType
 		if ct == "" {
@@ -100,7 +99,7 @@ func (c *Client) RoundTrip(in, out Message) error {
 		}
 		r.Header.Set("Content-Type", ct)
 		if in != nil {
-			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, reflect.TypeOf(in).Elem().Name()))
+			r.Header.Add("SOAPAction", fmt.Sprintf("%s/%s", c.Namespace, soapAction))
 		}
 	}
 	return doRoundTrip(c, headerFunc, in, out)

--- a/soap/client.go
+++ b/soap/client.go
@@ -50,11 +50,46 @@ type Client struct {
 	Pre                    func(*http.Request) // Optional hook to modify outbound requests
 }
 
+type XMLTyper interface {
+	SetXMLType()
+}
+
+func setXMLType(v reflect.Value) {
+	if !v.IsValid() {
+		return
+	}
+	switch v.Type().Kind() {
+	case reflect.Interface:
+		setXMLType(v.Elem())
+	case reflect.Ptr:
+		if v.IsNil() {
+			break
+		}
+		XMLTyperType := reflect.TypeOf((*XMLTyper)(nil)).Elem()
+		ok := v.Type().Implements(XMLTyperType)
+		if ok {
+			v.MethodByName("SetXMLType").Call([]reflect.Value{})
+		}
+		setXMLType(v.Elem())
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			setXMLType(v.Index(i))
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			setXMLType(v.Field(i))
+		}
+	default:
+	}
+	return
+}
+
 func doRoundTrip(c *Client, setHeaders func(*http.Request), in, out Message) error {
+	setXMLType(reflect.ValueOf(in))
 	req := &Envelope{
 		EnvelopeAttr: c.Envelope,
 		NSAttr:       c.Namespace,
-		XSIAttr:      c.XSINamespace,
+		XSIAttr:      XSINamespace,
 		Header:       c.Header,
 		Body:         Body{Message: in},
 	}

--- a/soap/client_test.go
+++ b/soap/client_test.go
@@ -1,12 +1,12 @@
 package soap
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
-	"fmt"
 )
 
 func TestRoundTrip(t *testing.T) {
@@ -28,27 +28,31 @@ func TestRoundTrip(t *testing.T) {
 	pre := func(r *http.Request) { r.Header.Set("X-Test", "true") }
 	cases := []struct {
 		C       *Client
+		Action  string
 		In, Out Message
 		Fail    bool
 	}{
 		{
-			C:   &Client{URL: s.URL, Pre: pre},
-			In:  &msgT{A: "hello", B: "world"},
-			Out: &envT{},
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "hello",
+			In:     &msgT{A: "hello", B: "world"},
+			Out:    &envT{},
 		},
 		{
-			C:   &Client{URL: s.URL, Pre: pre},
-			In:  &msgT{A: "foo", B: "bar"},
-			Out: &envT{},
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "foo",
+			In:     &msgT{A: "foo", B: "bar"},
+			Out:    &envT{},
 		},
 		{
-			C:    &Client{URL: "", Pre: pre},
-			Out:  &envT{},
-			Fail: true,
+			C:      &Client{URL: "", Pre: pre},
+			Action: "none",
+			Out:    &envT{},
+			Fail:   true,
 		},
 	}
 	for i, tc := range cases {
-		err := tc.C.RoundTrip(tc.In, tc.Out)
+		err := tc.C.RoundTrip(tc.Action, tc.In, tc.Out)
 		if err != nil && !tc.Fail {
 			t.Errorf("test %d: %v", i, err)
 			continue

--- a/soap/client_test.go
+++ b/soap/client_test.go
@@ -52,7 +52,71 @@ func TestRoundTrip(t *testing.T) {
 		},
 	}
 	for i, tc := range cases {
-		err := tc.C.RoundTrip(tc.Action, tc.In, tc.Out)
+		err := tc.C.RoundTrip(tc.In, tc.Out)
+		if err != nil && !tc.Fail {
+			t.Errorf("test %d: %v", i, err)
+			continue
+		}
+		if tc.Fail {
+			continue
+		}
+		env, ok := tc.Out.(*envT)
+		if !ok {
+			t.Errorf("test %d: response to %#v is not an envelope", i, tc.In)
+			continue
+		}
+		if !reflect.DeepEqual(env.Body.Message, *tc.In.(*msgT)) {
+			t.Errorf("test %d: message mismatch\nwant: %#v\nhave: %#v",
+				i, tc.In, &env.Body.Message)
+			continue
+		}
+	}
+}
+
+func TestRoundTripWithAction(t *testing.T) {
+	type msgT struct{ A, B string }
+	type envT struct{ Body struct{ Message msgT } }
+	echo := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			http.NotFound(w, r)
+			return
+		}
+		if v := r.Header.Get("X-Test"); v != "true" {
+			http.NotFound(w, r)
+			return
+		}
+		io.Copy(w, r.Body)
+	})
+	s := httptest.NewServer(echo)
+	defer s.Close()
+	pre := func(r *http.Request) { r.Header.Set("X-Test", "true") }
+	cases := []struct {
+		C       *Client
+		Action  string
+		In, Out Message
+		Fail    bool
+	}{
+		{
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "hello",
+			In:     &msgT{A: "hello", B: "world"},
+			Out:    &envT{},
+		},
+		{
+			C:      &Client{URL: s.URL, Pre: pre},
+			Action: "foo",
+			In:     &msgT{A: "foo", B: "bar"},
+			Out:    &envT{},
+		},
+		{
+			C:      &Client{URL: "", Pre: pre},
+			Action: "none",
+			Out:    &envT{},
+			Fail:   true,
+		},
+	}
+	for i, tc := range cases {
+		err := tc.C.RoundTripWithAction(tc.Action, tc.In, tc.Out)
 		if err != nil && !tc.Fail {
 			t.Errorf("test %d: %v", i, err)
 			continue

--- a/soap/client_test.go
+++ b/soap/client_test.go
@@ -9,6 +9,42 @@ import (
 	"testing"
 )
 
+type SetXmlData struct {
+	TypeAttrXSI, TypeNamespace string
+}
+
+func (s *SetXmlData) SetXMLType() {
+	s.TypeAttrXSI = "test"
+	s.TypeNamespace = "test 1"
+}
+
+func TestSetXMLType(t *testing.T) {
+	type interfaceT interface{}
+	type testT struct {
+		A string
+		B []interfaceT
+	}
+
+	test := &testT{
+		A: "unchanged",
+	}
+	list := []*SetXmlData{{}, {}}
+	test.B = make([]interfaceT, len(list))
+	for i, el := range list {
+		test.B[i] = el
+	}
+	setXMLType(reflect.ValueOf(test))
+	for _, interfaceEl := range test.B {
+		el, _ := interfaceEl.(*SetXmlData)
+		if el.TypeAttrXSI != "test" {
+			t.Fatal("TypeAttrXSI not set")
+		}
+		if el.TypeNamespace != "test 1" {
+			t.Fatal("TypeNamespace not set")
+		}
+	}
+}
+
 func TestRoundTrip(t *testing.T) {
 	type msgT struct{ A, B string }
 	type envT struct{ Body struct{ Message msgT } }

--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -203,8 +203,8 @@ type BindingOperation struct {
 // Soap12Operation.SoapAction is used to switch things over to sending
 // a soap 1.2 content type header (application/xml; charset=UTF-8; action='blah')
 type Soap12Operation struct {
-	XMLName    xml.Name   `xml:"http://schemas.xmlsoap.org/wsdl/soap12/ operation"`
-	SoapAction string     `xml:"soapAction,attr"`
+	XMLName    xml.Name `xml:"http://schemas.xmlsoap.org/wsdl/soap12/ operation"`
+	SoapAction string   `xml:"soapAction,attr"`
 }
 
 // BindingIO describes the IO binding of SOAP operations. See IO for details.

--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -6,17 +6,32 @@ import "encoding/xml"
 
 // Definitions is the root element of a WSDL document.
 type Definitions struct {
-	XMLName         xml.Name   `xml:"definitions"`
-	Name            string     `xml:"name,attr"`
-	TargetNamespace string     `xml:"targetNamespace,attr"`
-	SOAPEnv         string     `xml:"SOAP-ENV,attr"`
-	SOAPEnc         string     `xml:"SOAP-ENC,attr"`
-	Service         Service    `xml:"service"`
-	Imports         []*Import  `xml:"import"`
-	Schema          Schema     `xml:"types>schema"`
-	Messages        []*Message `xml:"message"`
-	PortType        PortType   `xml:"portType"` // TODO: PortType slice?
-	Binding         Binding    `xml:"binding"`
+	XMLName         xml.Name          `xml:"definitions"`
+	Name            string            `xml:"name,attr"`
+	TargetNamespace string            `xml:"targetNamespace,attr"`
+	Namespaces      map[string]string `xml:"-"`
+	SOAPEnv         string            `xml:"SOAP-ENV,attr"`
+	SOAPEnc         string            `xml:"SOAP-ENC,attr"`
+	Service         Service           `xml:"service"`
+	Imports         []*Import         `xml:"import"`
+	Schema          Schema            `xml:"types>schema"`
+	Messages        []*Message        `xml:"message"`
+	PortType        PortType          `xml:"portType"` // TODO: PortType slice?
+	Binding         Binding           `xml:"binding"`
+}
+
+type definitionDup Definitions
+
+func (def *Definitions) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for _, attr := range start.Attr {
+		if attr.Name.Space == "xmlns" {
+			if def.Namespaces == nil {
+				def.Namespaces = make(map[string]string)
+			}
+			def.Namespaces[attr.Name.Local] = attr.Value
+		}
+	}
+	return d.DecodeElement((*definitionDup)(def), &start)
 }
 
 // Service defines a WSDL service and with a location, like an HTTP server.
@@ -41,19 +56,41 @@ type Address struct {
 
 // Schema of WSDL document.
 type Schema struct {
-	XMLName      xml.Name        `xml:"schema"`
-	Imports      []*ImportSchema `xml:"import"`
-	SimpleTypes  []*SimpleType   `xml:"simpleType"`
-	ComplexTypes []*ComplexType  `xml:"complexType"`
-	Elements     []*Element      `xml:"element"`
+	XMLName         xml.Name          `xml:"schema"`
+	TargetNamespace string            `xml:"targetNamespace,attr"`
+	Namespaces      map[string]string `xml:"-"`
+	Imports         []*ImportSchema   `xml:"import"`
+	SimpleTypes     []*SimpleType     `xml:"simpleType"`
+	ComplexTypes    []*ComplexType    `xml:"complexType"`
+	Elements        []*Element        `xml:"element"`
+}
+
+// Unmarshaling solution from Matt Harden (http://grokbase.com/t/gg/golang-nuts/14bk21xb7a/go-nuts-extending-encoding-xml-to-capture-unknown-attributes)
+// We duplicate the type Schema here so that we can unmarshal into it
+// without recursively triggering the *Schema.UnmarshalXML method.
+// Other options are to embed tt into Type or declare Type as a synonym for tt.
+// The important thing is that tt is only used directly in *Schema.UnmarshalXML or Schema.MarshalXML.
+type schemaDup Schema
+
+func (schema *Schema) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for _, attr := range start.Attr {
+		if attr.Name.Space == "xmlns" {
+			if schema.Namespaces == nil {
+				schema.Namespaces = make(map[string]string)
+			}
+			schema.Namespaces[attr.Name.Local] = attr.Value
+		}
+	}
+	return d.DecodeElement((*schemaDup)(schema), &start)
 }
 
 // SimpleType describes a simple type, such as string.
 type SimpleType struct {
-	XMLName     xml.Name     `xml:"simpleType"`
-	Name        string       `xml:"name,attr"`
-	Union       *Union       `xml:"union"`
-	Restriction *Restriction `xml:"restriction"`
+	XMLName         xml.Name     `xml:"simpleType"`
+	Name            string       `xml:"name,attr"`
+	Union           *Union       `xml:"union"`
+	Restriction     *Restriction `xml:"restriction"`
+	TargetNamespace string
 }
 
 // Union is a mix of multiple types in a union.
@@ -78,14 +115,15 @@ type Enum struct {
 
 // ComplexType describes a complex type, such as a struct.
 type ComplexType struct {
-	XMLName        xml.Name        `xml:"complexType"`
-	Name           string          `xml:"name,attr"`
-	Abstract       bool            `xml:"abstract,attr"`
-	Doc            string          `xml:"annotation>documentation"`
-	AllElements    []*Element      `xml:"all>element"`
-	ComplexContent *ComplexContent `xml:"complexContent"`
-	Sequence       *Sequence       `xml:"sequence"`
-	Attributes     []*Attribute    `xml:"attribute"`
+	XMLName         xml.Name        `xml:"complexType"`
+	Name            string          `xml:"name,attr"`
+	Abstract        bool            `xml:"abstract,attr"`
+	Doc             string          `xml:"annotation>documentation"`
+	AllElements     []*Element      `xml:"all>element"`
+	ComplexContent  *ComplexContent `xml:"complexContent"`
+	Sequence        *Sequence       `xml:"sequence"`
+	Attributes      []*Attribute    `xml:"attribute"`
+	TargetNamespace string
 }
 
 // ComplexContent describes complex content within a complex type. Usually

--- a/wsdl/types.go
+++ b/wsdl/types.go
@@ -85,6 +85,7 @@ type ComplexType struct {
 	AllElements    []*Element      `xml:"all>element"`
 	ComplexContent *ComplexContent `xml:"complexContent"`
 	Sequence       *Sequence       `xml:"sequence"`
+	Attributes     []*Attribute    `xml:"attribute"`
 }
 
 // ComplexContent describes complex content within a complex type. Usually
@@ -96,9 +97,10 @@ type ComplexContent struct {
 
 // Extension describes a complex content extension.
 type Extension struct {
-	XMLName  xml.Name  `xml:"extension"`
-	Base     string    `xml:"base,attr"`
-	Sequence *Sequence `xml:"sequence"`
+	XMLName    xml.Name     `xml:"extension"`
+	Base       string       `xml:"base,attr"`
+	Sequence   *Sequence    `xml:"sequence"`
+	Attributes []*Attribute `xml:"attribute"`
 }
 
 // Sequence describes a list of elements (parameters) of a type.
@@ -107,6 +109,17 @@ type Sequence struct {
 	ComplexTypes []*ComplexType `xml:"complexType"`
 	Elements     []*Element     `xml:"element"`
 	Any          []*AnyElement  `xml:"any"`
+}
+
+// Element describes an element of a given type.
+type Attribute struct {
+	XMLName  xml.Name `xml:"attribute"`
+	Name     string   `xml:"name,attr"`
+	Ref      string   `xml:"ref,attr"`
+	Type     string   `xml:"type,attr"`
+	Min      int      `xml:"minOccurs,attr"`
+	Max      string   `xml:"maxOccurs,attr"` // can be # or unbounded
+	Nillable bool     `xml:"nillable,attr"`
 }
 
 // Element describes an element of a given type.

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -492,7 +492,7 @@ var soapFuncT = template.Must(template.New("soapFunc").Parse(
 			M {{.OutputType}} ` + "`xml:\"{{.XMLOutputType}}\"`" + `
 		}
 	}{}
-	if err = p.cli.RoundTrip("{{.Name}}", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("{{.Name}}", α, &γ); err != nil {
 		return {{.RetDef}}, err
 	}
 	return {{if .RetPtr}}&{{end}}γ.Body.M, nil

--- a/wsdlgo/encoder.go
+++ b/wsdlgo/encoder.go
@@ -65,7 +65,7 @@ type goEncoder struct {
 	needsTimeType     bool
 	needsDateTimeType bool
 	needsDurationType bool
-	needsTag          map[string]bool
+	needsTag          map[string]string
 	needsStdPkg       map[string]bool
 	needsExtPkg       map[string]bool
 }
@@ -81,7 +81,7 @@ func NewEncoder(w io.Writer) Encoder {
 		funcs:       make(map[string]*wsdl.Operation),
 		messages:    make(map[string]*wsdl.Message),
 		soapOps:     make(map[string]*wsdl.BindingOperation),
-		needsTag:    make(map[string]bool),
+		needsTag:    make(map[string]string),
 		needsStdPkg: make(map[string]bool),
 		needsExtPkg: make(map[string]bool),
 	}
@@ -492,7 +492,7 @@ var soapFuncT = template.Must(template.New("soapFunc").Parse(
 			M {{.OutputType}} ` + "`xml:\"{{.XMLOutputType}}\"`" + `
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("{{.Name}}", α, &γ); err != nil {
 		return {{.RetDef}}, err
 	}
 	return {{if .RetPtr}}&{{end}}γ.Body.M, nil
@@ -580,7 +580,6 @@ func (ge *goEncoder) writeSOAPFunc(w io.Writer, d *wsdl.Definitions, op *wsdl.Op
 	return true
 }
 
-
 func renameParam(p, name string) string {
 	v := strings.SplitN(p, " ", 2)
 	if len(v) != 2 {
@@ -660,13 +659,19 @@ func code(list []*parameter) []string {
 func (ge *goEncoder) genParams(m *wsdl.Message, needsTag bool) []*parameter {
 	params := make([]*parameter, len(m.Parts))
 	for i, param := range m.Parts {
-		var t, token string
+		var t, token, elName string
 		switch {
 		case param.Type != "":
 			t = ge.wsdl2goType(param.Type)
+			elName = ge.trimns(param.Type)
 			token = t
 		case param.Element != "":
-			t = ge.wsdl2goType(param.Element)
+			elName = ge.trimns(param.Element)
+			if el, ok := ge.elements[elName]; ok {
+				t = ge.wsdl2goType(ge.trimns(el.Type))
+			} else {
+				t = ge.wsdl2goType(param.Element)
+			}
 			token = ge.trimns(param.Element)
 		}
 		name := param.Name
@@ -675,7 +680,7 @@ func (ge *goEncoder) genParams(m *wsdl.Message, needsTag bool) []*parameter {
 		}
 		params[i] = &parameter{code: name + " " + t, xmlToken: token}
 		if needsTag {
-			ge.needsTag[strings.TrimPrefix(t, "*")] = true
+			ge.needsTag[strings.TrimPrefix(t, "*")] = elName
 		}
 	}
 	return params
@@ -965,9 +970,9 @@ func (ge *goEncoder) genGoStruct(w io.Writer, d *wsdl.Definitions, ct *wsdl.Comp
 		return nil
 	}
 	fmt.Fprintf(w, "type %s struct {\n", name)
-	if ge.needsTag[name] {
+	if elName, ok := ge.needsTag[name]; ok {
 		fmt.Fprintf(w, "XMLName xml.Name `xml:\"%s %s\" json:\"-\" yaml:\"-\"`\n",
-			d.TargetNamespace, ct.Name)
+			d.TargetNamespace, elName)
 	}
 	err := ge.genStructFields(w, d, ct)
 	if err != nil {

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -72,7 +72,7 @@ func (p *dataEndpointPortType) GetData(α *GetData) (β *GetDataResp, err error)
 			M GetDataResp `xml:"getDataResp"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetData", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -72,7 +72,7 @@ func (p *dataEndpointPortType) GetData(α *GetData) (β *GetDataResp, err error)
 			M GetDataResp `xml:"getDataResp"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetData", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetData", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -40,14 +40,30 @@ type DataGenerationReq struct {
 	CustomerAccountNumber string                `xml:"customerAccountNumber,omitempty" json:"customerAccountNumber,omitempty" yaml:"customerAccountNumber,omitempty"`
 	PdfGenerationReqType  int                   `xml:"pdfGenerationReqType,omitempty" json:"pdfGenerationReqType,omitempty" yaml:"pdfGenerationReqType,omitempty"`
 	WithCreditTranferForm bool                  `xml:"withCreditTranferForm,omitempty" json:"withCreditTranferForm,omitempty" yaml:"withCreditTranferForm,omitempty"`
+	TypeAttrXSI           string                `xml:"xsi:type,attr,omitempty"`
+	TypeNamespace         string                `xml:"xmlns:objtype,attr,omitempty"`
+}
+
+// SetXMLType was auto-generated from WSDL.
+func (t *DataGenerationReq) SetXMLType() {
+	t.TypeAttrXSI = "objtype:DataGenerationReq"
+	t.TypeNamespace = "http://pdf.host.com/xsd"
 }
 
 // DataGenerationResp was auto-generated from WSDL.
 type DataGenerationResp struct {
-	ErrorDetails *ErrorDetails `xml:"errorDetails,omitempty" json:"errorDetails,omitempty" yaml:"errorDetails,omitempty"`
-	Success      bool          `xml:"success,omitempty" json:"success,omitempty" yaml:"success,omitempty"`
-	Pdf          []byte        `xml:"pdf,omitempty" json:"pdf,omitempty" yaml:"pdf,omitempty"`
-	Url          string        `xml:"url,omitempty" json:"url,omitempty" yaml:"url,omitempty"`
+	ErrorDetails  *ErrorDetails `xml:"errorDetails,omitempty" json:"errorDetails,omitempty" yaml:"errorDetails,omitempty"`
+	Success       bool          `xml:"success,omitempty" json:"success,omitempty" yaml:"success,omitempty"`
+	Pdf           []byte        `xml:"pdf,omitempty" json:"pdf,omitempty" yaml:"pdf,omitempty"`
+	Url           string        `xml:"url,omitempty" json:"url,omitempty" yaml:"url,omitempty"`
+	TypeAttrXSI   string        `xml:"xsi:type,attr,omitempty"`
+	TypeNamespace string        `xml:"xmlns:objtype,attr,omitempty"`
+}
+
+// SetXMLType was auto-generated from WSDL.
+func (t *DataGenerationResp) SetXMLType() {
+	t.TypeAttrXSI = "objtype:DataGenerationResp"
+	t.TypeNamespace = "http://pdf.host.com/xsd"
 }
 
 // GetData was auto-generated from WSDL.

--- a/wsdlgo/testdata/data.golden
+++ b/wsdlgo/testdata/data.golden
@@ -24,6 +24,7 @@ type DataEndpointPortType interface {
 // BaseReq was auto-generated from WSDL.
 type BaseReq struct {
 	ClientIdentification *ClientIdentification `xml:"clientIdentification,omitempty" json:"clientIdentification,omitempty" yaml:"clientIdentification,omitempty"`
+	TestAttr             string                `xml:"TestAttr,attr,omitempty" json:"TestAttr,attr,omitempty" yaml:"TestAttr,attr,omitempty"`
 }
 
 // BaseResp was auto-generated from WSDL.
@@ -35,6 +36,7 @@ type BaseResp struct {
 // DataGenerationReq was auto-generated from WSDL.
 type DataGenerationReq struct {
 	ClientIdentification  *ClientIdentification `xml:"clientIdentification,omitempty" json:"clientIdentification,omitempty" yaml:"clientIdentification,omitempty"`
+	TestAttr              string                `xml:"TestAttr,attr,omitempty" json:"TestAttr,attr,omitempty" yaml:"TestAttr,attr,omitempty"`
 	CustomerAccountNumber string                `xml:"customerAccountNumber,omitempty" json:"customerAccountNumber,omitempty" yaml:"customerAccountNumber,omitempty"`
 	PdfGenerationReqType  int                   `xml:"pdfGenerationReqType,omitempty" json:"pdfGenerationReqType,omitempty" yaml:"pdfGenerationReqType,omitempty"`
 	WithCreditTranferForm bool                  `xml:"withCreditTranferForm,omitempty" json:"withCreditTranferForm,omitempty" yaml:"withCreditTranferForm,omitempty"`

--- a/wsdlgo/testdata/data.wsdl
+++ b/wsdlgo/testdata/data.wsdl
@@ -23,6 +23,7 @@
                 <xs:sequence>
                     <xs:element minOccurs="0" name="clientIdentification" nillable="true" type="ax2179:ClientIdentification"/>
                 </xs:sequence>
+                <xs:attribute name="TestAttr" type="xs:string"></xs:attribute>
             </xs:complexType>
             <xs:complexType name="BaseResp">
                 <xs:sequence>

--- a/wsdlgo/testdata/memcache.golden
+++ b/wsdlgo/testdata/memcache.golden
@@ -51,7 +51,7 @@ type SetRequest struct {
 
 // GetMultiRequest was auto-generated from WSDL.
 type GetMultiRequest struct {
-	XMLName xml.Name `xml:"http://localhost:8080/MemoryService.wsdl getMultiRequest" json:"-" yaml:"-"`
+	XMLName xml.Name `xml:"http://localhost:8080/MemoryService.wsdl GetMultiRequest" json:"-" yaml:"-"`
 	Keys    []string `xml:"Keys" json:"Keys" yaml:"Keys"`
 }
 
@@ -68,7 +68,7 @@ func (p *memoryServicePortType) Get(α string) (β *GetResponse, err error) {
 			M GetResponse `xml:"GetResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("Get", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -82,7 +82,7 @@ func (p *memoryServicePortType) GetMulti(α *GetMultiRequest) (β *GetMultiRespo
 			M GetMultiResponse `xml:"GetMultiResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetMulti", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -96,7 +96,7 @@ func (p *memoryServicePortType) Set(α *SetRequest) (β bool, err error) {
 			M bool `xml:"bool"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("Set", α, &γ); err != nil {
 		return false, err
 	}
 	return γ.Body.M, nil

--- a/wsdlgo/testdata/memcache.golden
+++ b/wsdlgo/testdata/memcache.golden
@@ -68,7 +68,7 @@ func (p *memoryServicePortType) Get(α string) (β *GetResponse, err error) {
 			M GetResponse `xml:"GetResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("Get", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("Get", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -82,7 +82,7 @@ func (p *memoryServicePortType) GetMulti(α *GetMultiRequest) (β *GetMultiRespo
 			M GetMultiResponse `xml:"GetMultiResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetMulti", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetMulti", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil
@@ -96,7 +96,7 @@ func (p *memoryServicePortType) Set(α *SetRequest) (β bool, err error) {
 			M bool `xml:"bool"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("Set", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("Set", α, &γ); err != nil {
 		return false, err
 	}
 	return γ.Body.M, nil

--- a/wsdlgo/testdata/soap12wcf.golden
+++ b/wsdlgo/testdata/soap12wcf.golden
@@ -18,7 +18,7 @@ func NewTest(cli *soap.Client) Test {
 // and defines interface for the remote service. Useful for testing.
 type Test interface {
 	// HelloWorld was auto-generated from WSDL.
-	HelloWorld(α *HelloRequest) (β *HelloResponse, err error)
+	HelloWorld(α string) (β string, err error)
 }
 
 // test implements the Test interface.
@@ -27,15 +27,15 @@ type test struct {
 }
 
 // HelloWorld was auto-generated from WSDL.
-func (p *test) HelloWorld(α *HelloRequest) (β *HelloResponse, err error) {
+func (p *test) HelloWorld(α string) (β string, err error) {
 	γ := struct {
 		XMLName xml.Name `xml:"Envelope"`
 		Body    struct {
-			M HelloResponse `xml:"HelloResponse"`
+			M string `xml:"HelloResponse"`
 		}
 	}{}
 	if err = p.cli.RoundTripSoap12("http://example.com/Test/HelloWorldRequest", α, &γ); err != nil {
-		return nil, err
+		return "", err
 	}
-	return &γ.Body.M, nil
+	return γ.Body.M, nil
 }

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -51,7 +51,7 @@ func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(α *GetEndorsingBoarde
 			M GetEndorsingBoarderResponse `xml:"GetEndorsingBoarderResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetEndorsingBoarder", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetEndorsingBoarder", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example1.golden
+++ b/wsdlgo/testdata/w3example1.golden
@@ -51,7 +51,7 @@ func (p *getEndorsingBoarderPortType) GetEndorsingBoarder(α *GetEndorsingBoarde
 			M GetEndorsingBoarderResponse `xml:"GetEndorsingBoarderResponse"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetEndorsingBoarder", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -45,7 +45,7 @@ func (p *stockQuotePortType) GetLastTradePrice(α *TradePriceRequest) (β *Trade
 			M TradePrice `xml:"TradePrice"`
 		}
 	}{}
-	if err = p.cli.RoundTrip(α, &γ); err != nil {
+	if err = p.cli.RoundTrip("GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil

--- a/wsdlgo/testdata/w3example2.golden
+++ b/wsdlgo/testdata/w3example2.golden
@@ -45,7 +45,7 @@ func (p *stockQuotePortType) GetLastTradePrice(α *TradePriceRequest) (β *Trade
 			M TradePrice `xml:"TradePrice"`
 		}
 	}{}
-	if err = p.cli.RoundTrip("GetLastTradePrice", α, &γ); err != nil {
+	if err = p.cli.RoundTripWithAction("GetLastTradePrice", α, &γ); err != nil {
 		return nil, err
 	}
 	return &γ.Body.M, nil


### PR DESCRIPTION
- All types inhereted from abstract should use explicit XML type definition
- Add GO function for setting correct XML type to Go struct Tag
- Applying this function before sending request